### PR TITLE
Update Cryptomator to 1.18.0

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -25,4 +25,4 @@ atf.id = Cryptomator
 atf.win64.filename = ${atf.id}-${app.version}-win64
 atf.win64.ext = .msi
 atf.win64.url = https://github.com/cryptomator/cryptomator/releases/download/${app.version}/Cryptomator-${app.version}-x64.msi
-atf.win64.assertextract = ${msi.app}/Cryptomator/Cryptomator.exe
+atf.win64.assertextract = ${msi.app}/Cryptomator.exe

--- a/build.properties
+++ b/build.properties
@@ -5,8 +5,8 @@ core.dir = ../portapps
 app = cryptomator
 app.name = Cryptomator
 app.type = msi
-app.version = 1.15.2
-app.release = 15
+app.version = 1.18.0
+app.release = 15.1  
 app.homepage = https://cryptomator.org/
 
 # Portable app

--- a/build.properties
+++ b/build.properties
@@ -25,4 +25,4 @@ atf.id = Cryptomator
 atf.win64.filename = ${atf.id}-${app.version}-win64
 atf.win64.ext = .msi
 atf.win64.url = https://github.com/cryptomator/cryptomator/releases/download/${app.version}/Cryptomator-${app.version}-x64.msi
-atf.win64.assertextract = Cryptomator.exe
+atf.win64.assertextract = ${msi.app}/PFiles64/Cryptomator/Cryptomator.exe

--- a/build.properties
+++ b/build.properties
@@ -18,11 +18,11 @@ papp.url = https://github.com/portapps/${papp.id}
 papp.folder = app
 
 # MSI
-msi.app = SourceDir
+msi.app = SourceDir/PFiles64
 
 # Official artifacts
 atf.id = Cryptomator
 atf.win64.filename = ${atf.id}-${app.version}-win64
 atf.win64.ext = .msi
 atf.win64.url = https://github.com/cryptomator/cryptomator/releases/download/${app.version}/Cryptomator-${app.version}-x64.msi
-atf.win64.assertextract = ${msi.app}/PFiles64/Cryptomator/Cryptomator.exe
+atf.win64.assertextract = ${msi.app}/Cryptomator/Cryptomator.exe

--- a/build.properties
+++ b/build.properties
@@ -25,4 +25,4 @@ atf.id = Cryptomator
 atf.win64.filename = ${atf.id}-${app.version}-win64
 atf.win64.ext = .msi
 atf.win64.url = https://github.com/cryptomator/cryptomator/releases/download/${app.version}/Cryptomator-${app.version}-x64.msi
-atf.win64.assertextract = ${msi.app}/Cryptomator.exe
+atf.win64.assertextract = Cryptomator.exe


### PR DESCRIPTION
Attempt to update Cryptomator using [activescott/essays]（ https://github.com/activescott/lessmsi ）Check the new internal path in the Cryptomator installation package and update the ` msi. app ` variable.

Problem encountered during use: Error GH1B: GH1B: JCKJ occurs when mounting using WebMAV (Windows Explorer)

The discussions related to cryptomator are as follows:
[Error GH1B:GH1B:JCKJ](https://github.com/cryptomator/cryptomator/discussions/3410)